### PR TITLE
fix triggering of nonexistent neutrality event

### DIFF
--- a/common/on_actions/EAI_on_actions.txt
+++ b/common/on_actions/EAI_on_actions.txt
@@ -11,7 +11,7 @@ on_actions = {
 			every_country  = { limit = { is_ai = yes } add_ideas = ns }
 			
 			#AI neutrality ideas
-			USA = { country_event = EAI_D.0 }
+			USA = { country_event = EAI_DM.0 }
 			
 			#AI construction
 			GER = { country_event = EAI_C.0 }


### PR DESCRIPTION
I'm _pretty sure_ that this is the event you intended to trigger on the USA, `EAI_DM.0` and not `EAI_D.0`.